### PR TITLE
[FIX] sale_stock_operating_unit: remove auto set warehouse with id 1.

### DIFF
--- a/sale_stock_operating_unit/models/sale_order.py
+++ b/sale_stock_operating_unit/models/sale_order.py
@@ -52,13 +52,18 @@ class SaleOrder(models.Model):
 
     @api.onchange("warehouse_id")
     def onchange_warehouse_id(self):
-        if self.warehouse_id:
+        if self.warehouse_id and not self.operating_unit_id:
             self.operating_unit_id = self.warehouse_id.operating_unit_id
             if (
                 self.team_id
                 and self.team_id.operating_unit_id != self.operating_unit_id
             ):
                 self.team_id = False
+        warehouses = self.env["stock.warehouse"].search(
+                [("operating_unit_id", "=", self.operating_unit_id.id)], limit=1
+            )
+        if warehouses:
+            self.warehouse_id = warehouses[0]
 
     @api.constrains("operating_unit_id", "warehouse_id")
     def _check_wh_operating_unit(self):


### PR DESCRIPTION
if your user has a default operating, in a sale order by defect set false the field operating unit and set in field warehouse_id by default any warehouse than has id 1. This is a fix for this bug.